### PR TITLE
Fix: regex pattern in KwargsHandler

### DIFF
--- a/src/cmd_parser/core.py
+++ b/src/cmd_parser/core.py
@@ -40,7 +40,7 @@ class ArgsHandler(AbstractTokenHandler):
 
 
 class KwargsHandler(AbstractTokenHandler):
-    pattern = r'([a-z_]+[0-9_]+)=(?:[\"\'])?([a-zA-Z0-9_\s]+)(?:[\"\'])?'
+    pattern = r'([a-z_]+[0-9_]?+)=(?:[\"\'])?([a-zA-Z0-9_\s]+)(?:[\"\'])?'
     kind = 'kwargs'
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,19 +6,25 @@ from cmd_parser.core import asdict, parse
 class TestParser:
     @pytest.fixture(autouse=True)
     def setup(self) -> None:
-        self.command = '!command arg1 arg2 param1=value1 param2=value2'
+        self.command = (
+            '!command arg1 arg2 param=value param1=value1 arg param2=value2'
+        )
 
     def test_given_command_as_input_it_should_return_5_tokens(self):
         input_test = len(list(parse(self.command)))
-        expected = 5
-        assert input_test, expected
+        expected = 7
+        assert input_test == expected
 
     def test_given_command_as_input_it_should_return_a_dict(self):
         result = asdict(parse(self.command))
         expected = {
             'command': 'command',
-            'args': ['arg1', 'arg2'],
-            'kwargs': {'param1': 'value1', 'param2': 'value2'},
+            'args': ['arg1', 'arg2', 'arg'],
+            'kwargs': {
+                'param1': 'value1',
+                'param2': 'value2',
+                'param': 'value',
+            },
         }
         assert result == expected
 
@@ -37,3 +43,10 @@ def test_should_catch_value_erro_exception_for_malformed_inputs(
     with pytest.raises(expected_exception=ValueError, match=expected) as exc:
         asdict(parse(input_test))
     assert str(exc.value) == expected
+
+
+def test_given_named_param_as_input_it_should_return_valid_kwargs_dict():
+    input_test = 'param=value'
+    expected = {'command': None, 'args': [], 'kwargs': {'param': 'value'}}
+    result = asdict(parse(input_test))
+    assert result == expected


### PR DESCRIPTION
Fix the regex pattern in the KwargsHandler class to properly match
named parameters with optional trailing digits or underscores. The
corresponding test case for parsing named parameters has also been
added.
